### PR TITLE
Fixes #1 TypeError caused by using pos arg

### DIFF
--- a/cmd2_ext_test/cmd2_ext_test.py
+++ b/cmd2_ext_test/cmd2_ext_test.py
@@ -26,7 +26,7 @@ class ExternalTestMixin:
         try:
             self._in_py = True
 
-            return self._pybridge(command, echo)
+            return self._pybridge(command, echo=echo)
 
         finally:
             self._in_py = False


### PR DESCRIPTION
Just a small fix to tackle the reported `TypeError`.

The signature of the PyBridge was changed to force echo to be a kwarg
however it was being supplied a kwarg.  Fixed.